### PR TITLE
Use snapshot version of org.semver where we implemented fixes necessary for strongbox#611

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <version.jtwig>5.87.0.RELEASE</version.jtwig>
         <version.jacoco>0.8.2</version.jacoco>
         <version.codacy.mvn.plugin>1.1.0</version.codacy.mvn.plugin>
-		<version.semver>0.9.34-SNAPSHOT</version.semver>
+        <version.semver>0.9.34-SNAPSHOT</version.semver>
         <!-- Version properties. -->
         <surefireArgLine/>
         <failsafeArgLine/>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <version.jtwig>5.87.0.RELEASE</version.jtwig>
         <version.jacoco>0.8.2</version.jacoco>
         <version.codacy.mvn.plugin>1.1.0</version.codacy.mvn.plugin>
+		<version.semver>0.9.34-SNAPSHOT</version.semver>
         <!-- Version properties. -->
         <surefireArgLine/>
         <failsafeArgLine/>
@@ -995,7 +996,7 @@
             <dependency>
                 <groupId>org.semver</groupId>
                 <artifactId>api</artifactId>
-                <version>0.9.33</version>
+                <version>${version.semver}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
As we already discussed in chat `org.semver.Version$Special` had issues with equals which we had to resolve to fix `Verison` clients unit tests - the thing is this project is archived in github so we decided to fork it to implement the fix.

So this PR is about starting to use this fix in strongbox. This is a prerequisite for https://github.com/strongbox/strongbox/issues/611