### PR TITLE
Updates gmavenplus-plugin version to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
                 <plugin>
                     <groupId>org.codehaus.gmavenplus</groupId>
                     <artifactId>gmavenplus-plugin</artifactId>
-                    <version>1.5</version>
+                    <version>1.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Updates gmavenplus-plugin version to 1.6 so we can benefit from execute goal scripts provided as direct paths. This is a prerequisite to fix [#1157](https://github.com/strongbox/strongbox/issues/1157)