### PR TITLE
Issue-1255: Upgrade the version of Jetty.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <version.junit.jupiter>5.4.0</version.junit.jupiter>
         <version.junit.platform>1.4.0</version.junit.platform>
         <version.jersey>2.23.1</version.jersey>
-        <version.jetty>9.4.18.v20190425</version.jetty>
+        <version.jetty>9.4.18.v20190429</version.jetty>
         <version.jna>4.5.2</version.jna>
         <version.lucene>4.8.1</version.lucene>
         <version.logback>1.2.3</version.logback>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <version.junit.jupiter>5.4.0</version.junit.jupiter>
         <version.junit.platform>1.4.0</version.junit.platform>
         <version.jersey>2.23.1</version.jersey>
-        <version.jetty>9.4.6.v20170531</version.jetty>
+        <version.jetty>9.4.18.v20190425</version.jetty>
         <version.jna>4.5.2</version.jna>
         <version.lucene>4.8.1</version.lucene>
         <version.logback>1.2.3</version.logback>


### PR DESCRIPTION
Fixes strongbox/strongbox#1255.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.