### PR TITLE
SB1456: Adding AssertJ dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         <version.codacy.mvn.plugin>1.1.0</version.codacy.mvn.plugin>
         <version.semver>0.9.34-SNAPSHOT</version.semver>
         <version.springfox>2.9.2</version.springfox>
+        <version.assertj>3.13.2</version.assertj>
         <!-- Version properties. -->
         <surefireArgLine/>
         <failsafeArgLine/>
@@ -990,6 +991,12 @@
                 <artifactId>hamcrest-all</artifactId>
                 <version>${version.hamcrest}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.assertj}</version>
+                 <scope>test</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Adding AssertJ dependency explicitly as an initial step to standardization of tests assertions to AssertJ https://github.com/strongbox/strongbox/issues/1456
The plan is to ...
1. Add AssertJ dependency in parent-pom
2. replace org.hamcrest.*Matchers by their AssertJ counterparts and drop <groupId>org.hamcrest</groupId> dependency from pom.xml files
3. replace org.junit.jupiter.api.Assertions by their AssertJ counterparts
4. exclude <groupId>org.hamcrest</groupId> from dependency tree in parent-pom