### PR TITLE
Issue-1397: Upgrade commons-http to version 1.3 and commons-io to 1.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <version.maven.indexer>6.0.1-SNAPSHOT</version.maven.indexer>
 
         <version.carlspring.commons.io>1.0</version.carlspring.commons.io>
-        <version.carlspring.commons.http>1.0</version.carlspring.commons.http>
+        <version.carlspring.commons.http>1.1</version.carlspring.commons.http>
         <version.carlspring.logback.config>1.0</version.carlspring.logback.config>
         <version.carlspring.npm.metadata>1.0-SNAPSHOT</version.carlspring.npm.metadata>
 
@@ -405,13 +405,13 @@
         <dependencies>
             <dependency>
                 <groupId>org.carlspring.commons</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${version.carlspring.commons.io}</version>
+                <artifactId>commons-http</artifactId>
+                <version>${version.carlspring.commons.http}</version>
             </dependency>
             <dependency>
                 <groupId>org.carlspring.commons</groupId>
-                <artifactId>commons-http</artifactId>
-                <version>${version.carlspring.commons.http}</version>
+                <artifactId>commons-io</artifactId>
+                <version>${version.carlspring.commons.io}</version>
             </dependency>
             <dependency>
                 <groupId>org.carlspring.logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <version.maven.indexer>6.0.1-SNAPSHOT</version.maven.indexer>
 
         <version.carlspring.commons.io>1.0</version.carlspring.commons.io>
-        <version.carlspring.commons.http>1.1</version.carlspring.commons.http>
+        <version.carlspring.commons.http>1.2.1</version.carlspring.commons.http>
         <version.carlspring.logback.config>1.0</version.carlspring.logback.config>
         <version.carlspring.npm.metadata>1.0-SNAPSHOT</version.carlspring.npm.metadata>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-PR-39-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
         <!-- Version properties: -->
         <version.maven.indexer>6.0.1-SNAPSHOT</version.maven.indexer>
 
-        <version.carlspring.commons.io>1.0</version.carlspring.commons.io>
-        <version.carlspring.commons.http>1.2.1</version.carlspring.commons.http>
+        <version.carlspring.commons.io>1.1</version.carlspring.commons.io>
+        <version.carlspring.commons.http>1.3</version.carlspring.commons.http>
         <version.carlspring.logback.config>1.0</version.carlspring.logback.config>
         <version.carlspring.npm.metadata>1.0-SNAPSHOT</version.carlspring.npm.metadata>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-PR-39-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>


### PR DESCRIPTION
Related to strongbox/strongbox#1397.
This PR should be merged at the same time as PR strongbox/strongbox#1474.

## Tasks
- [x] Upgrade to `commons-http` to version `1.3`, which validates byte ranges.
- [x] Upgrade to `commons-io` to version `1.1`, which uses `ByteRange` from `commons-http` to avoid conflicts.