### PR TITLE
issues/1566: upgrade Awaitility to 4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <version.liquibase>3.6.3</version.liquibase>
         <version.reflections>0.9.11</version.reflections>
         <version.liquibase.slf4j>2.0.0</version.liquibase.slf4j>
-        <version.awaitility>3.1.2</version.awaitility>
+        <version.awaitility>4.0.1</version.awaitility>
         <version.asm>6.0</version.asm>
         <version.jtwig>5.87.0.RELEASE</version.jtwig>
         <version.jacoco>0.8.2</version.jacoco>


### PR DESCRIPTION
Updated pom.xml file to upgrade Awaitility to 4.0.1.

This fixes strongbox/strongbox#1566.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.
