### PR TITLE
Issue #1565 - org.apache.tomcat:catalina dependency has been dropped …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1299,19 +1299,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>catalina</artifactId>
-                <version>6.0.53</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.tomcat</groupId>
-                        <artifactId>servlet-api</artifactId>
-                    </exclusion>
-                </exclusions>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>com.github.ThoughtWire</groupId>
                 <artifactId>hazelcast-locks</artifactId>
                 <version>v1.0.1</version>


### PR DESCRIPTION
# Task Description
We should no longer need this dependency. This task should verify this theory, and, if so, we should remove this from all pom.xml files.

# Tasks
The following tasks will need to be carried out:

- [x] Remove this from the strongbox-proto-parent) project.
- [x] Remove this from the strongbox-parent) project.
- [x] Remove this from all pom.xml files in the strongbox project.

# Acceptance Test
 - [x] Building the code with mvn clean install -Dintegration.tests still works.
 - [x] Running mvn spring-boot:run in the strongbox-web-core still starts up the application correctly.
 - [x] Building the code and running the strongbox-distribution from a zip or tar.gz still works.
 - [~] The tests in the strongbox-web-integration-tests still run properly.

was not able to get the gradle s-w-i-t task running as it kept failing to build javadocs (very likely because of my build environment)

>[INFO] Using Groovy 2.4.7 to perform execute.
>Test test-gradle-common-flow.groovy
>Target directory: C:\Users\M4n1us\git\hacktober\strongbox-web-integration-tests\gradle\target
>Base directory: C:\Users\M4n1us\git\hacktober\strongbox-web-integration-tests\gradle
>Gradle path: C:\Users\M4n1us\git\hacktober\strongbox-web-integration-tests\gradle
>C:\Users\M4n1us\git\hacktober\strongbox-web-integration-tests\gradle\gradlew.bat
>Execute command[s]: 
>C:\Users\M4n1us\git\hacktober\strongbox-web-integration-tests\gradle\gradlew.bat upload ->Dcredentials.username=deployer -Dcredentials.password=password
>Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details
> \> Task :compileJava UP-TO-DATE
> \> Task :processResources NO-SOURCE
> \> Task :classes UP-TO-DATE
> \> Task :jar UP-TO-DATE
> \> Task :javadoc FAILED
> Unable to find the 'javadoc' executable. Tried the java home: C:\Program Files\JetBrains\IntelliJ IDEA >2019.2\jbr and the PATH. We will assume the executable can be ran in the current working folder.
>3 actionable tasks: 1 executed, 2 up-to-date
>gave the following error: 
>[ERROR] 
>FAILURE: Build failed with an exception.
> What went wrong:
> Execution failed for task ':javadoc'.
>\> Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): 'C:\Users\M4n1us\git\hacktober\strongbox-web-integration-tests\gradle\src\it\common-flow\build\tmp\javadoc\javadoc.options'
> Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
> Get more help at https://help.gradle.org
BUILD FAILED in 5s`