### PR TITLE
Drop the org.apache.tomcat:catalina dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1299,19 +1299,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>catalina</artifactId>
-                <version>6.0.53</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.tomcat</groupId>
-                        <artifactId>servlet-api</artifactId>
-                    </exclusion>
-                </exclusions>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>com.github.ThoughtWire</groupId>
                 <artifactId>hazelcast-locks</artifactId>
                 <version>v1.0.1</version>


### PR DESCRIPTION
Fixes [strongbox #1565](https://github.com/strongbox/strongbox/issues/1565#issue-513023450)

Sorry for late PR, spent some time trying to make the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) work on my local environment. I couldn't find any `catalina` dependency in the [strongbox](https://github.com/strongbox/strongbox/) project so only update other two projects. The tests all passed successfully on my machine after dropping this dependency.

### Task

- [x] Remove this from the [strongbox-proto-parent](https://github.com/strongbox/strongbox-proto-parent/) project.
- [x] Remove this from the [strongbox-parent](https://github.com/strongbox/strongbox-parent/) project.
- [x] Remove this from all `pom.xml` files in the [strongbox](https://github.com/strongbox/strongbox/) project.

### Acceptance Tests

- [x] Building the code with `mvn clean install -Dintegration.tests` still works.
- [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
- [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
- [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.