### PR TITLE
Issue-1857: Upgrade swagger dependencies from 1.5.18 to 1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-issue-1857-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-issue-1857-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>
@@ -609,7 +609,7 @@
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-core</artifactId>
                 <scope>compile</scope>
-                <version>1.5.18</version>
+                <version>1.6.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.validation</groupId>


### PR DESCRIPTION
This PR addresses [#Issue-1857](https://github.com/strongbox/strongbox/issues/1857)

Incremented swagger core version from 1.5.18 to 1.6.2.