### PR TITLE
Issue-1852: Upgrade our JUnit dependencies from 5.4.0 to 5.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <version.jcl>1.7.25</version.jcl>
         <version.jsr305>3.0.2</version.jsr305>
         <version.findbugs.annotations>3.0.1</version.findbugs.annotations>
-        <version.junit.jupiter>5.4.0</version.junit.jupiter>
+        <version.junit.jupiter>5.7.0</version.junit.jupiter>
         <version.jersey>2.23.1</version.jersey>
         <version.jetty>9.4.18.v20190429</version.jetty>
         <version.jna>4.5.2</version.jna>

--- a/pom.xml
+++ b/pom.xml
@@ -851,6 +851,12 @@
                 <groupId>org.codehaus.mojo.appassembler</groupId>
                 <artifactId>appassembler-model</artifactId>
                 <version>${version.appassembler}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.1</version>
+                    <version>3.0.0-M5</version>
                     <inherited>true</inherited>
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>
@@ -200,7 +200,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.22.1</version>
+                    <version>3.0.0-M5</version>
 
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>
@@ -1383,6 +1383,10 @@
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
                     <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
                 </exclusion>
              </exclusions>
         </dependency>


### PR DESCRIPTION
- [x] upgrade junit version to 5.7.0
- [x] exlcude junit under org.codehaus.mojo.appassembler:appassembler-model

**cc:** @carlspring  @sbespalov  @steve-todorov 