### PR TITLE
Issue 1853: Upgrade our hamcrest dependencies from 1.3 to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.appassembler>2.0.0</version.appassembler>
         <version.groovy>2.4.7</version.groovy>
         <version.guava>27.0.1-jre</version.guava>
-        <version.hamcrest>1.3</version.hamcrest>
+        <version.hamcrest>2.2</version.hamcrest>
         <version.hazelcast>3.10.2</version.hazelcast>
         <version.httpclient>4.5</version.httpclient>
         <version.jackson>2.10.0</version.jackson>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-issue-1853-dep-upgrade-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-issue-1853-dep-upgrade-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>


### PR DESCRIPTION
# Pull Request Description

Related to issue strongbox/strongbox#1853.
This PR should be merged before the PR strongbox/strongbox/pull/1890

## Tasks
- [x] Upgrade `hamcrest` to version `2.2`.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
