### PR TITLE
Issue-1861: Upgraded commons-io version to 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-issue-1861-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>
@@ -61,7 +61,7 @@
         <version.carlspring.logback.config>1.0</version.carlspring.logback.config>
         <version.carlspring.npm.metadata>1.0-SNAPSHOT</version.carlspring.npm.metadata>
 
-        <version.apache.commons.io>2.6</version.apache.commons.io>
+        <version.apache.commons.io>2.8.0</version.apache.commons.io>
         <version.apache.commons.compress>1.19</version.apache.commons.compress>
         <version.apache.directory>1.5.5</version.apache.directory>
         <version.appassembler>2.0.0</version.appassembler>


### PR DESCRIPTION
This pull request fixes strongbox/strongbox#1861.

Incremented `commons-io` version from `2.6` to `2.8.0`. Successfully ran the integration tests and confirmed the dependency tree does not contain any other version that `2.8.0`.