### PR TITLE
Issue 1874: Upgrade the org.codehaus.mojo:build-helper-maven-plugin from 1.9.1 to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <version.carlspring.commons.io>1.1</version.carlspring.commons.io>
         <version.carlspring.commons.http>1.3</version.carlspring.commons.http>
         <version.carlspring.logback.config>1.0</version.carlspring.logback.config>
-        <version.carlspring.npm.metadata>1.0-issue-1874-SNAPSHOT</version.carlspring.npm.metadata>
+        <version.carlspring.npm.metadata>1.0-SNAPSHOT</version.carlspring.npm.metadata>
 
         <version.apache.commons.io>2.6</version.apache.commons.io>
         <version.apache.commons.compress>1.19</version.apache.commons.compress>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-issue-1874-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>
@@ -59,7 +59,7 @@
         <version.carlspring.commons.io>1.1</version.carlspring.commons.io>
         <version.carlspring.commons.http>1.3</version.carlspring.commons.http>
         <version.carlspring.logback.config>1.0</version.carlspring.logback.config>
-        <version.carlspring.npm.metadata>1.0-SNAPSHOT</version.carlspring.npm.metadata>
+        <version.carlspring.npm.metadata>1.0-issue-1874-SNAPSHOT</version.carlspring.npm.metadata>
 
         <version.apache.commons.io>2.6</version.apache.commons.io>
         <version.apache.commons.compress>1.19</version.apache.commons.compress>
@@ -290,7 +290,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>1.9.1</version>
+                    <version>3.2.0</version>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-issue-1874-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>


### PR DESCRIPTION
# Pull Request Description

This pull request closes strongbox/strongbox#1874

# Acceptance Test

* [x] Building the code of the [`strongbox-parent`](https://github.com/strongbox/strongbox-parent) with `mvn clean install` still works.
* [x] Building the code of the [`strongbox`](https://github.com/strongbox/strongbox) project with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No

# Code Review And Pre-Merge Checklist

* [x] My code follows the [coding convention](https://strongbox.github.io/developer-guide/coding-convention.html) of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code in hard-to-understand areas.
* [ ] My changes generate no new warnings.
