### PR TITLE
Issue 1910: Upgrade our Jersey dependencies from 2.23.1 to 2.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <version.jsr305>3.0.2</version.jsr305>
         <version.findbugs.annotations>3.0.1</version.findbugs.annotations>
         <version.junit.jupiter>5.4.0</version.junit.jupiter>
-        <version.jersey>2.23.1</version.jersey>
+        <version.jersey>2.32</version.jersey>
         <version.jetty>9.4.18.v20190429</version.jetty>
         <version.jna>4.5.2</version.jna>
         <version.lucene>4.8.1</version.lucene>
@@ -781,6 +781,11 @@
             <dependency>
                 <groupId>org.glassfish.jersey.connectors</groupId>
                 <artifactId>jersey-apache-connector</artifactId>
+                <version>${version.jersey}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.inject</groupId>
+                <artifactId>jersey-hk2</artifactId>
                 <version>${version.jersey}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-issue-1910-dep-upgrade-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-issue-1910-dep-upgrade-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>


### PR DESCRIPTION
# Pull Request Description

This pull request closes strongbox/strongbox#1910

# Acceptance Test

* [x] Building the code of the [`strongbox-parent`](https://github.com/strongbox/strongbox-parent) with `mvn clean install` still works.
* [x] Building the code of the [`strongbox`](https://github.com/strongbox/strongbox) project with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No

# Code Review And Pre-Merge Checklist

* [x] My code follows the [coding convention](https://strongbox.github.io/developer-guide/coding-convention.html) of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code in hard-to-understand areas.
* [x] My changes generate no new warnings.
