### PR TITLE
Add a rule using the maven-enforcer plugin that requires JDK 8 or 11 #1865

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,47 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <rules>
+                                <bannedPlugins>
+                                    <level>ERROR</level>
+                                </bannedPlugins>
+                                <requireMavenVersion>
+                                    <version>[3.6.3,)</version>
+                                    <message>Invalid Maven version, the minimum required is 3.6.3.</message>
+                                </requireMavenVersion>
+                            </rules>
+                            <fail>true</fail>
+                            <failFast>true</failFast>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                     <version>[1.8.0-241,1.9),[11.3, 12)</version>
+                                    <message>Invalid JDK version, minimum required is 1.8.0_241 for JDK 8 or 11.3 for JDK 11.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+				</executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
# Pull Request Description

This pull request closes strongbox/strongbox#1865

# Acceptance Test

* [X] Building the code of the [`strongbox-parent`](https://github.com/strongbox/strongbox-parent) with `mvn clean install` still works.
* [X] Building the code of the [`strongbox`](https://github.com/strongbox/strongbox) project with `mvn clean install -Dintegration.tests` still works.
* [X] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [X] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [X] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [X] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [X] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [X] No

# Code Review And Pre-Merge Checklist

* [X] My code follows the [coding convention](https://strongbox.github.io/developer-guide/coding-convention.html) of this project.
* [X] I have performed a self-review of my own code.
* [X] I have commented my code in hard-to-understand areas.
* [X] My changes generate no new warnings.
