### PR TITLE
Issue 1870: Upgrade the maven-surefire-plugin and maven-failsafe-plugin to 3.0.0-M5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-issue-1870-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Strongbox: Parent</name>
@@ -157,7 +157,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.1</version>
+                    <version>3.0.0-M5</version>
                     <inherited>true</inherited>
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>
@@ -199,7 +199,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.22.1</version>
+                    <version>3.0.0-M5</version>
 
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>


### PR DESCRIPTION
- Upgraded plugin versions and changed project version

# Pull Request Description

This pull request closes strongbox/strongbox/issues/1870  

# Acceptance Test

* [X] Building the code of the [`strongbox-parent`](https://github.com/strongbox/strongbox-parent) with `mvn clean install` still works.
* [X] Building the code of the [`strongbox`](https://github.com/strongbox/strongbox) project with `mvn clean install -Dintegration.tests` still works.
* [X] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [X] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [X] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [X] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [X] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [X] No

# Code Review And Pre-Merge Checklist

* [X] My code follows the [coding convention](https://strongbox.github.io/developer-guide/coding-convention.html) of this project.
* [X] I have performed a self-review of my own code.
* [ ] I have commented my code in hard-to-understand areas.
* [ ] My changes generate no new warnings.
